### PR TITLE
refector: 사이드바 카테고리 링크 활성화 상태 확인 로직 개선

### DIFF
--- a/components/sidebar/category-sidebar.tsx
+++ b/components/sidebar/category-sidebar.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 
+import { ROUTES } from "@/lib/routes";
 import { cn } from "@/lib/utils";
 
 import {
@@ -17,9 +18,13 @@ import {
 } from "../ui/sidebar";
 import { COMMUNITY_CATEGORY_LIST, RANK_CATEGORY_LIST } from "./constant";
 
-const ROUTES = {
-  RANK: "/rank",
-} as const;
+// ROUTES.rank 및 ROUTES.community 문자열 값 기반 타입
+type RankRouteValue = (typeof ROUTES.rank)[keyof typeof ROUTES.rank];
+type CommunityRouteValue = Extract<
+  (typeof ROUTES.community)[keyof typeof ROUTES.community],
+  string
+>;
+type CategoryRouteValue = RankRouteValue | CommunityRouteValue;
 
 const SIDEBAR_STYLES = {
   CONTAINER: "bg-white w-full p-4 border border-gray-100 rounded-10",
@@ -34,7 +39,7 @@ const SIDEBAR_STYLES = {
 const MENU_ITEM_STYLES = {
   BASE: "label-medium bg-white text-gray-600 rounded-[10px] h-11.5 w-full hover:text-frog-600 hover:bg-white",
   ACTIVE: "text-frog-600 bg-frog-100 transition-300",
-  LINK: "w-full",
+  LINK: cn("w-full"),
 } as const;
 
 interface CategorySidebarProps {
@@ -59,7 +64,7 @@ export function ProgSidebar() {
 
   // 현재 경로에 따라 사이드바 목록 결정
   const sidebarList = useMemo(() => {
-    return pathname.includes(ROUTES.RANK)
+    return pathname.includes(ROUTES.rank.ROOT)
       ? RANK_CATEGORY_LIST
       : COMMUNITY_CATEGORY_LIST;
   }, [pathname]);
@@ -100,15 +105,19 @@ function CategorySidebar({ title, children }: CategorySidebarProps) {
  * 카테고리 목록을 순회하며 링크 아이템을 생성합니다.
  */
 function CategorySidebarItem({ categories }: CategorySidebarItemProps) {
-  const pathname = usePathname();
+  // const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const categoryParam = searchParams.get("category") || "";
 
-  // 활성 상태 확인 함수
-  const isActive = (href: string): boolean => {
-    return pathname.includes(href);
+  // 활성 상태 확인 함수 (ROUTES.rank 또는 ROUTES.community 값과 비교)
+  const isActive = (href: CategoryRouteValue): boolean => {
+    const [, query] = href.split("?");
+    const params = new URLSearchParams(query ?? "");
+    return (params.get("category") ?? "") === categoryParam;
   };
 
   // 메뉴 아이템 스타일 계산 함수
-  const getMenuItemStyle = (href: string): string => {
+  const getMenuItemStyle = (href: CategoryRouteValue): string => {
     return isActive(href)
       ? cn(MENU_ITEM_STYLES.BASE, MENU_ITEM_STYLES.ACTIVE)
       : MENU_ITEM_STYLES.BASE;

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -405,7 +405,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        "text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-sidebar-foreground/70 flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear [&>svg]:size-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className
       )}
@@ -426,7 +426,7 @@ function SidebarGroupAction({
       data-slot="sidebar-group-action"
       data-sidebar="group-action"
       className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform [&>svg]:size-4 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 md:after:hidden",
         "group-data-[collapsible=icon]:hidden",
@@ -474,7 +474,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -561,7 +561,7 @@ function SidebarMenuAction({
       data-slot="sidebar-menu-action"
       data-sidebar="menu-action"
       className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform [&>svg]:size-4 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 md:after:hidden",
         "peer-data-[size=sm]/menu-button:top-1",
@@ -686,7 +686,7 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden  disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
         "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
         size === "sm" && "text-xs",
         size === "md" && "text-sm",


### PR DESCRIPTION
## 🛠️ 변경 사항
> 무엇을 변경했는지 간결하게 설명해주세요.

- rank sidebar category에 맞게 active 값 변경


## 📸 스크린샷 (선택)
> UI 변경이 있는 경우 스크린샷을 첨부해주세요.

<img width="566" height="520" alt="스크린샷 2026-02-27 오후 4 20 26" src="https://github.com/user-attachments/assets/2d24c4bb-42e7-40da-8c80-a29ede031c30" />

<img width="456" height="530" alt="스크린샷 2026-02-27 오후 4 20 20" src="https://github.com/user-attachments/assets/650029ae-9b07-4dca-aee4-168bff118497" />


## ✅ 체크리스트
- [ ] 빌드 에러가 발생하지 않는가?
- [ ] 정해진 디자인 시스템(Color, Font)을 준수하였는가?
- [ ] 불필요한 console.log는 제거하였는가?

## 🔗 연결된 이슈
- Closes #37 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 사이드바 네비게이션 컴포넌트의 포커스 링 스타일링을 개선했습니다
  * 사이드바 요소 전체의 간격과 정렬을 최적화했습니다

* **리팩터**
  * 카테고리 사이드바 라우팅 로직을 업데이트했습니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->