### PR TITLE
chore: SEO 설정

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import { headers } from "next/headers";
 import { AuthWatcher } from "@/components/auth/auth-watcher";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { Toaster } from "@/components/ui/sonner";
+import { SITE_URL } from "@/lib/site";
 
 import AuthProvider from "./providers/auth-provider";
 import QueryProvider from "./providers/queryProvider";
@@ -20,6 +21,7 @@ const pretendard = localFont({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: "PROG - 현직자 프롬프트 공유 커뮤니티",
   description:
     "현직자들이 실제 사용한 프롬프트를 공유하는 커뮤니티. 자소서 작성부터 합격까지, PROG와 함께 도약하세요.",

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from "next";
+
+import { SITE_URL } from "@/lib/site";
+
+/**
+ * 루트 `/robots.txt`를 생성한다(Next.js 파일 컨벤션).
+ * 공개 콘텐츠는 허용하고, 어드민·마이페이지·API·작성/수정 등 비공개 경로는 차단한다.
+ */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: [
+        "/admin",
+        "/mypage",
+        "/api/",
+        "/prompt/write",
+        "/prompt/*/edit",
+        "/auth-callback",
+      ],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,36 @@
+import type { MetadataRoute } from "next";
+
+import { SITE_URL } from "@/lib/site";
+
+/**
+ * 루트 `/sitemap.xml`을 생성한다(Next.js 파일 컨벤션).
+ *
+ * **범위: 정적 공개 라우트만.** 동적 프롬프트 상세(`/prompt/[id]`)는 인증 fetcher 의존으로
+ * 빌드시점 수집에 제약이 있어 P1로 유보한다(원장 YT-SEO-001).
+ */
+const STATIC_ROUTES = [
+  { path: "/", changeFrequency: "daily", priority: 1 },
+  { path: "/community", changeFrequency: "hourly", priority: 0.9 },
+  { path: "/rank", changeFrequency: "daily", priority: 0.8 },
+  { path: "/search", changeFrequency: "weekly", priority: 0.5 },
+  { path: "/terms/faq.html", changeFrequency: "monthly", priority: 0.4 },
+  { path: "/terms/terms.html", changeFrequency: "yearly", priority: 0.3 },
+  { path: "/terms/privacy.html", changeFrequency: "yearly", priority: 0.3 },
+] as const satisfies ReadonlyArray<{
+  path: string;
+  changeFrequency: NonNullable<
+    MetadataRoute.Sitemap[number]["changeFrequency"]
+  >;
+  priority: number;
+}>;
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
+  return STATIC_ROUTES.map((route) => ({
+    url: `${SITE_URL}${route.path}`,
+    lastModified,
+    changeFrequency: route.changeFrequency,
+    priority: route.priority,
+  }));
+}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,12 @@
+/**
+ * 사이트 절대 URL 단일 소스(Single Source of Truth).
+ *
+ * `metadataBase`, `robots`, `sitemap` 등 절대 URL이 필요한 모든 곳이 이 값을 참조한다.
+ * 배포 환경에서는 `NEXT_PUBLIC_SITE_URL`로 오버라이드하고, 미설정 시 운영 도메인으로 폴백한다.
+ */
+const FALLBACK_SITE_URL = "https://keep-prog.com";
+
+/** 후행 슬래시가 제거된 절대 URL. 경로 연결(`${SITE_URL}${path}`) 시 이중 슬래시를 방지한다. */
+export const SITE_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL?.trim() || FALLBACK_SITE_URL
+).replace(/\/+$/, "");


### PR DESCRIPTION
## 🛠️ 변경 사항

- app/robots.ts: /robots.txt: 공개 허용 + [admin, mypage, api, write, edit, auth-callback] 차단
- app/sitemap.ts: /sitemap.xml: 정적 공개 라우트만 포함
- lib/site.ts: SITE_URL 단일 소스 (NEXT_PUBLIC_SITE_URL, 못찾을 시 keep-prog.com)

## ✅ 체크리스트
- [ ] 빌드 에러가 발생하지 않는가?
- [ ] 정해진 디자인 시스템(Color, Font)을 준수하였는가?
- [ ] 불필요한 console.log는 제거하였는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 사이트의 절대 URL 기준이 통일되어, 메타데이터와 검색 엔진용 설정이 더 일관되게 적용됩니다.
  * `/robots.txt`와 `/sitemap.xml`이 새로 제공되어 검색 엔진 노출이 개선됩니다.

* **Bug Fixes**
  * 메타데이터의 기준 URL이 올바르게 설정되도록 개선했습니다.
  * URL 끝의 슬래시 처리로 잘못된 이중 슬래시 연결을 방지했습니다.
  * 공개/비공개 경로에 대한 검색 엔진 접근 규칙을 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->