### PR TITLE
feat: Google Tag Manager(GTM-MD22QF5W) 설치

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "./styles/globals.css";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import { headers } from "next/headers";
+import Script from "next/script";
 
 import { AuthWatcher } from "@/components/auth/auth-watcher";
 import { SidebarProvider } from "@/components/ui/sidebar";
@@ -40,7 +41,28 @@ export default async function RootLayout({
       nonce={nonce}
       suppressHydrationWarning
     >
+      <head>
+        <Script
+          id="gtm-script"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MD22QF5W');`,
+          }}
+        />
+      </head>
       <body className={`${pretendard.className} antialiased`}>
+        <noscript>
+          <iframe
+            src="https://www.googletagmanager.com/ns.html?id=GTM-MD22QF5W"
+            height="0"
+            width="0"
+            style={{ display: "none", visibility: "hidden" }}
+          />
+        </noscript>
         <AuthProvider>
           <AuthWatcher />
           <QueryProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -45,6 +45,7 @@ export default async function RootLayout({
         <Script
           id="gtm-script"
           strategy="afterInteractive"
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
## 🛠️ 변경 사항
> 무엇을 변경했는지 간결하게 설명해주세요.

- Google Tag Manager(GTM-MD22QF5W) 스크립트를 루트 `layout.tsx`에 설치
- `<head>` 영역에 `next/script`(`afterInteractive` 전략)로 GTM 스크립트 삽입
- `<body>` 시작 직후에 JavaScript 비활성화 환경을 위한 `<noscript>` fallback 추가
- 루트 레이아웃에 적용되어 모든 페이지에 자동 반영

## 📸 스크린샷 (선택)
> UI 변경 없음 (스크립트 태그만 추가)

## ✅ 체크리스트
- [x] 빌드 에러가 발생하지 않는가?
- [x] 정해진 디자인 시스템(Color, Font)을 준수하였는가?
- [x] 불필요한 console.log는 제거하였는가?

## 🔗 연결된 이슈
- 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * Google Tag Manager를 연동해 웹사이트 이용 데이터를 보다 일관되게 측정할 수 있습니다.
  * 페이지가 로드된 후에도 태그가 안정적으로 초기화되며, 스크립트를 지원하지 않는 환경에서도 기본 추적이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->