### PR TITLE
feat: Microsoft Clarity(xq9uail2t7) 추적 스크립트 설치

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -54,6 +54,18 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','GTM-MD22QF5W');`,
           }}
         />
+        <Script
+          id="ms-clarity-script"
+          strategy="afterInteractive"
+          nonce={nonce}
+          dangerouslySetInnerHTML={{
+            __html: `(function(c,l,a,r,i,t,y){
+c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+})(window,document,"clarity","script","xq9uail2t7");`,
+          }}
+        />
       </head>
       <body className={`${pretendard.className} antialiased`}>
         <noscript>

--- a/proxy.ts
+++ b/proxy.ts
@@ -82,7 +82,7 @@ export default auth((req) => {
     `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`, // 필요시 스타일에도 'nonce-${nonce}' 교체 가능
     "font-src 'self' https://fonts.gstatic.com",
     "img-src 'self' data: blob: https:",
-    `connect-src 'self' ${process.env.NEXT_PUBLIC_BACKEND_API_URL || ""}`,
+    `connect-src 'self' ${process.env.NEXT_PUBLIC_BACKEND_API_URL || ""} https://www.clarity.ms https://*.clarity.ms`,
     "frame-ancestors 'none'",
   ].join("; ");
 


### PR DESCRIPTION
## 🛠️ 변경 사항
> 무엇을 변경했는지 간결하게 설명해주세요.

- Microsoft Clarity(xq9uail2t7) 추적 스크립트를 루트 `layout.tsx`에 설치
- `<head>` 영역에 `next/script`(`afterInteractive` 전략)로 Clarity 스크립트 삽입
- CSP 차단 방지를 위해 `nonce` 전달
- 루트 레이아웃에 적용되어 모든 페이지에 자동 반영

## 📸 스크린샷 (선택)
> UI 변경 없음 (스크립트 태그만 추가)

## ✅ 체크리스트
- [x] 빌드 에러가 발생하지 않는가?
- [x] 정해진 디자인 시스템(Color, Font)을 준수하였는가?
- [x] 불필요한 console.log는 제거하였는가?

## 🔗 연결된 이슈
- 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * Microsoft Clarity 분석 도구를 추가해 서비스 이용 현황을 파악할 수 있습니다.
  * 페이지 로드 후 추적 스크립트가 실행되도록 적용해 초기 로딩 성능에 미치는 영향을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->