### PR TITLE
Qa/P2 항목 정리

### DIFF
--- a/app/(afterLogin)/(dashboard)/(community-category)/rank/RankList.tsx
+++ b/app/(afterLogin)/(dashboard)/(community-category)/rank/RankList.tsx
@@ -8,7 +8,6 @@ import { PromptBase } from "@/app/types/type";
 import PromptCard from "@/components/prompt/prompt-card";
 import PromptCardSkeleton from "@/components/prompt/prompt-card-skeleton";
 import ReportModal from "@/components/prompt/report-modal";
-import { toasts } from "@/components/shared/toast";
 import {
   Dialog,
   DialogContent,
@@ -16,6 +15,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useCopyPrompt } from "@/hooks/use-copy-prompt";
 import {
   useGetPrompts,
   useReportMutation,
@@ -30,19 +30,8 @@ export interface PromptInfo extends PromptBase {
   bookmarks?: number;
 }
 
-const handleCopy = async (content: string) => {
-  try {
-    const el = document.createElement("div");
-    el.innerHTML = content;
-    const plainText = el.textContent ?? "";
-    await navigator.clipboard.writeText(plainText);
-    toasts.success("프롬프트가 클립보드에 복사되었습니다!");
-  } catch {
-    alert("복사에 실패했습니다. 다시 시도해주세요.");
-  }
-};
-
 export default function RankingList({ category }: { category: string }) {
+  const { copyById } = useCopyPrompt();
   const { mutate } = useToggleLikeMutation();
   const { mutate: reportMutate } = useReportMutation();
   const { ref, inView } = useInView();
@@ -113,7 +102,7 @@ export default function RankingList({ category }: { category: string }) {
             {...prompt}
             isLiked={!!prompt.isLiked}
             onLike={handleLike}
-            onCopy={() => handleCopy(prompt.contentSummary || "")}
+            onCopy={() => copyById(prompt.promptId)}
             onReport={() =>
               setReport((prev) => ({
                 ...prev,

--- a/app/(afterLogin)/mypage/MypageActivity.tsx
+++ b/app/(afterLogin)/mypage/MypageActivity.tsx
@@ -8,13 +8,14 @@ import {
   MyArticleCard,
 } from "@/components/mypage/articleCard";
 import { PaginationButton } from "@/components/pagination-button/pagination-button";
-import { toasts } from "@/components/shared/toast";
+import { useCopyPrompt } from "@/hooks/use-copy-prompt";
 import { useSubTabFilters } from "@/hooks/use-filters";
 import { useLikedPrompts, useUserPrompts } from "@/hooks/use-mypage";
 import { cn } from "@/lib/utils";
 
 export default function MypageActivitySection() {
   const router = useRouter();
+  const { copyById } = useCopyPrompt();
 
   const { currentSub, currentPage, handleSubTabChange, handlePageChange } =
     useSubTabFilters("mypage");
@@ -35,14 +36,9 @@ export default function MypageActivitySection() {
     enabled: !!userId && activeSub === "posted",
   });
 
-  const handleCopy = async (e: React.MouseEvent, content: string) => {
+  const handleCopy = (e: React.MouseEvent, promptId: number) => {
     e.stopPropagation();
-    try {
-      await navigator.clipboard.writeText(content);
-      toasts.success("프롬프트가 클립보드에 복사되었습니다!");
-    } catch {
-      alert("복사에 실패했습니다.");
-    }
+    copyById(promptId);
   };
 
   const handleCardClick = (id: number) => {
@@ -104,7 +100,7 @@ export default function MypageActivitySection() {
                 key={prompt.promptId}
                 title={prompt.title}
                 contentSummary={prompt.contentSummary}
-                onCopy={(e) => handleCopy(e, prompt.contentSummary)}
+                onCopy={(e) => handleCopy(e, prompt.promptId)}
                 onClick={() => handleCardClick(prompt.promptId)}
               />
             ) : (

--- a/app/(afterLogin)/prompt/[id]/_components/comment-form.tsx
+++ b/app/(afterLogin)/prompt/[id]/_components/comment-form.tsx
@@ -8,7 +8,7 @@ import { BaseButton } from "@/components/shared/button";
 import { toasts } from "@/components/shared/toast";
 import { promptQueries } from "@/queries/options/prompt-query";
 
-const MAX_COMMENT_LENGTH = 1000;
+import { MAX_COMMENT_LENGTH } from "../../constant";
 
 interface CommentFormProps {
   promptId: string | number;

--- a/app/(afterLogin)/prompt/[id]/_components/comment-item.tsx
+++ b/app/(afterLogin)/prompt/[id]/_components/comment-item.tsx
@@ -19,10 +19,9 @@ import { useReportMutation } from "@/hooks/use-prompt-list";
 import { PromptCommentResponse } from "@/queries/api/prompts";
 import { promptQueries } from "@/queries/options/prompt-query";
 
+import { MAX_COMMENT_LENGTH } from "../../constant";
 import { CommentForm } from "./comment-form";
 import { formatCommentDate } from "./utils";
-
-const MAX_COMMENT_LENGTH = 1000;
 
 interface CommentItemProps {
   comment: PromptCommentResponse;

--- a/app/(afterLogin)/prompt/[id]/_components/post-detail.tsx
+++ b/app/(afterLogin)/prompt/[id]/_components/post-detail.tsx
@@ -17,6 +17,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useCopyPrompt } from "@/hooks/use-copy-prompt";
 import { useReportMutation } from "@/hooks/use-prompt-list";
 import { ROUTES } from "@/lib/routes";
 import { cn } from "@/lib/utils";
@@ -71,6 +72,7 @@ export function PostDetail({ promptId, prompt, user }: PostDetailProps) {
   const [report, setReport] = useState({ open: false, reason: "", detail: "" });
   const [deleteConfirm, setDeleteConfirm] = useState(false);
   const queryClient = useQueryClient();
+  const { copyContent } = useCopyPrompt();
   const { mutate: reportMutate } = useReportMutation();
 
   const isOwner = !!user?.id && String(user.id) === String(prompt.userId);
@@ -110,17 +112,9 @@ export function PostDetail({ promptId, prompt, user }: PostDetailProps) {
     },
   });
 
-  const handleCopy = useCallback(async () => {
-    try {
-      const el = document.createElement("div");
-      el.innerHTML = prompt.content;
-      const plainText = el.textContent ?? "";
-      await navigator.clipboard.writeText(plainText);
-      toasts.success("프롬프트가 복사되었습니다.");
-    } catch {
-      toasts.error("클립보드 복사에 실패했습니다.");
-    }
-  }, [prompt.content]);
+  const handleCopy = useCallback(() => {
+    copyContent(prompt.content);
+  }, [copyContent, prompt.content]);
 
   const handleLikeClick = useCallback(() => {
     if (!user) {

--- a/app/(afterLogin)/prompt/constant.ts
+++ b/app/(afterLogin)/prompt/constant.ts
@@ -1,1 +1,2 @@
 export const MAX_BOARD_CONTENT_LENGTH = 5000;
+export const MAX_COMMENT_LENGTH = 255;

--- a/components/board/quill-board.tsx
+++ b/components/board/quill-board.tsx
@@ -6,6 +6,32 @@ import ReactQuill from "react-quill-new";
 
 import { cn } from "@/lib/utils";
 
+// 본문에 이미지를 넣을 수 없도록 허용 포맷에서 image/video 를 제외한다.
+// 툴바가 비어 있어 이미지 버튼은 없지만, Quill 은 드롭·붙여넣기로 들어온 이미지를
+// base64 로 본문에 박아 넣는다(uploader 모듈이 기본 활성).
+// 50KB 사진 한 장이면 base64 로 약 68,000자가 되어 content 컬럼(TEXT, 65,535 bytes)을
+// 그대로 넘긴다. 저장은 실패하는데 사용자는 이유를 알 수 없다. (P2-18)
+const ALLOWED_FORMATS = [
+  "bold",
+  "italic",
+  "underline",
+  "strike",
+  "script",
+  "code",
+  "code-block",
+  "blockquote",
+  "header",
+  "list",
+  "indent",
+  "align",
+  "direction",
+  "link",
+  "color",
+  "background",
+  "font",
+  "size",
+];
+
 interface QuillBoardProps extends Omit<
   React.ComponentProps<typeof ReactQuill>,
   "onChange"
@@ -27,7 +53,11 @@ export default function QuillBoard({
     <ReactQuill
       modules={{
         toolbar: [],
+        // 허용 MIME 을 비워 드롭·붙여넣기한 이미지 파일이 base64 로 변환되지 않게 한다.
+        // 모듈 자체를 끄면 clipboard 가 quill.uploader 를 참조하다 터지므로 남겨둔다.
+        uploader: { mimetypes: [] },
       }}
+      formats={ALLOWED_FORMATS}
       {...props}
       value={value}
       onChange={setValue}

--- a/components/board/quill-board.tsx
+++ b/components/board/quill-board.tsx
@@ -6,11 +6,8 @@ import ReactQuill from "react-quill-new";
 
 import { cn } from "@/lib/utils";
 
-// 본문에 이미지를 넣을 수 없도록 허용 포맷에서 image/video 를 제외한다.
-// 툴바가 비어 있어 이미지 버튼은 없지만, Quill 은 드롭·붙여넣기로 들어온 이미지를
-// base64 로 본문에 박아 넣는다(uploader 모듈이 기본 활성).
-// 50KB 사진 한 장이면 base64 로 약 68,000자가 되어 content 컬럼(TEXT, 65,535 bytes)을
-// 그대로 넘긴다. 저장은 실패하는데 사용자는 이유를 알 수 없다. (P2-18)
+// 툴바에 이미지 버튼이 없어도 Quill 은 드롭·붙여넣기한 이미지를 base64 로 본문에
+// 삽입한다. image/video 를 빼서 막는다.
 const ALLOWED_FORMATS = [
   "bold",
   "italic",
@@ -53,8 +50,8 @@ export default function QuillBoard({
     <ReactQuill
       modules={{
         toolbar: [],
-        // 허용 MIME 을 비워 드롭·붙여넣기한 이미지 파일이 base64 로 변환되지 않게 한다.
-        // 모듈 자체를 끄면 clipboard 가 quill.uploader 를 참조하다 터지므로 남겨둔다.
+        // uploader: false 로 끄면 clipboard 가 quill.uploader 를 참조하다 터진다.
+        // 모듈은 남기고 허용 MIME 만 비운다.
         uploader: { mimetypes: [] },
       }}
       formats={ALLOWED_FORMATS}

--- a/components/header/header-right-section.tsx
+++ b/components/header/header-right-section.tsx
@@ -142,21 +142,35 @@ function LinkItem({
   label: string;
   newTab?: boolean;
 }) {
+  const inner = (
+    <>
+      <span className="label-medium">{label}</span>
+      <ChevronRightIcon
+        className="size-5"
+        color="#111111"
+        width={7}
+        height={5}
+      />
+    </>
+  );
+  const className = "h-12 flex items-center justify-between";
+
   return (
     <DrawerClose asChild>
-      <Link
-        className="h-12 flex items-center justify-between"
-        href={href}
-        {...(newTab && { target: "_blank", rel: "noopener noreferrer" })}
-      >
-        <span className="label-medium">{label}</span>
-        <ChevronRightIcon
-          className="size-5"
-          color="#111111"
-          width={7}
-          height={5}
-        />
-      </Link>
+      {newTab ? (
+        <a
+          className={className}
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {inner}
+        </a>
+      ) : (
+        <Link className={className} href={href}>
+          {inner}
+        </Link>
+      )}
     </DrawerClose>
   );
 }

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -50,15 +50,13 @@ export function HeaderNavigation() {
               key={nav.href}
               className="text-gray-900 navigation-large hover:text-frog-600"
             >
-              <Link
-                href={nav.href}
-                {...(nav.newTab && {
-                  target: "_blank",
-                  rel: "noopener noreferrer",
-                })}
-              >
-                {nav.label}
-              </Link>
+              {nav.newTab ? (
+                <a href={nav.href} target="_blank" rel="noopener noreferrer">
+                  {nav.label}
+                </a>
+              ) : (
+                <Link href={nav.href}>{nav.label}</Link>
+              )}
             </li>
           );
         })}

--- a/components/terms/terms-check.tsx
+++ b/components/terms/terms-check.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useId } from "react";
 
 import { cn } from "@/lib/utils";
@@ -112,14 +111,14 @@ const CheckboxItem = ({
       />
     </div>
     {showLink && link && (
-      <Link
+      <a
         href={link}
         className={cn(TERMS_STYLES.SHOW_LINK, "whitespace-nowrap pt-1")}
         target="_blank"
         rel="noopener noreferrer"
       >
         보기
-      </Link>
+      </a>
     )}
   </div>
 );

--- a/hooks/use-copy-prompt.ts
+++ b/hooks/use-copy-prompt.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+import { toasts } from "@/components/shared/toast";
+import { htmlToPlainText } from "@/lib/utils";
+import { promptQueries } from "@/queries/options/prompt-query";
+
+export function useCopyPrompt() {
+  const queryClient = useQueryClient();
+
+  const write = useCallback(async (content: string) => {
+    const plainText = htmlToPlainText(content);
+    if (!plainText) {
+      toasts.error("복사할 내용이 없습니다.");
+      return;
+    }
+    await navigator.clipboard.writeText(plainText);
+    toasts.success("프롬프트가 복사되었습니다.");
+  }, []);
+
+  const copyContent = useCallback(
+    async (content: string) => {
+      try {
+        await write(content);
+      } catch {
+        toasts.error("클립보드 복사에 실패했습니다.");
+      }
+    },
+    [write]
+  );
+
+  const copyById = useCallback(
+    async (promptId: number) => {
+      try {
+        const detail = await queryClient.fetchQuery(
+          promptQueries.detail(promptId)
+        );
+        await write(detail?.content ?? "");
+      } catch {
+        toasts.error("클립보드 복사에 실패했습니다.");
+      }
+    },
+    [queryClient, write]
+  );
+
+  return { copyContent, copyById };
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -36,6 +36,9 @@ export const { handlers, auth, signIn, signOut, update } = NextAuth({
             body: JSON.stringify({
               provider: account.provider.toUpperCase(),
               accessToken: account.access_token,
+              // 탈퇴 시 소셜 연동을 끊으려면 서버가 리프레시 토큰을 보관해야 한다.
+              // 액세스 토큰은 약 1시간 뒤 만료되므로 탈퇴 시점에는 쓸 수 없다. (P2-22)
+              refreshToken: account.refresh_token,
             }),
           }
         );

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -36,8 +36,7 @@ export const { handlers, auth, signIn, signOut, update } = NextAuth({
             body: JSON.stringify({
               provider: account.provider.toUpperCase(),
               accessToken: account.access_token,
-              // 탈퇴 시 소셜 연동을 끊으려면 서버가 리프레시 토큰을 보관해야 한다.
-              // 액세스 토큰은 약 1시간 뒤 만료되므로 탈퇴 시점에는 쓸 수 없다. (P2-22)
+              // 서버가 탈퇴 시 소셜 연동 해제에 사용한다.
               refreshToken: account.refresh_token,
             }),
           }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -72,6 +72,19 @@ export function stripHtml(html: string) {
     .trim();
 }
 
+const BLOCK_CLOSE_TAG = /<\/(p|div|h[1-6]|li|blockquote|tr)>/gi;
+const BR_TAG = /<br\s*\/?>/gi;
+
+export function htmlToPlainText(html: string) {
+  if (!html) return "";
+  const withBreaks = html
+    .replace(BR_TAG, "\n")
+    .replace(BLOCK_CLOSE_TAG, "$&\n");
+  return stripHtml(withBreaks)
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 export const clearAuthCookiesClientSide = () => {
   const cookiesToClear = [
     "next-auth.session-token",


### PR DESCRIPTION
## 🛠️ 변경 사항
- P2-19 | 댓글 길이 제한: 백엔드와 동일한 255자로 통일
- P2-20 | 프롬프트 복사 기능: 미리보기에 표시된 summary가 아닌, 전문을 복사하도록 수정 + 반복되어 사용하는 기능 훅으로 리팩토링
- P2-23 | 약관과 관련하여, 정적으로 서빙되고 있는 페이지를 내부 라우트로 취급하여 호출하였기에 404 오류 발생
  - GET /terms/faq.html : 200 OK
  - GET /terms/faq.html + RSC:1 + Next-Router-Prefetch:1 : 404 NOT FOUND
- P2-18 | 프롬프트 작성 시, 이미지 첨부 원칙적으로도 금지 (DB에 HTML 원문이 그대로 저장되므로, Base64 형태 혹은 img 태그를 이용하여 평문 형태로 첨부가 가능했었음, 이 상황을 방지)
- P2-22 | (서버 배포 후 검증 필요) 회원 탈퇴 시, 소셜 계정 연동 해제를 위한 socialRefreshToken을 FE측에서 버리고 있었음. 이 부분을 서버로 보내, 정상적인 계정 연동 해제가 가능하도록 수정

## ✅ 체크리스트
- [x] 빌드 에러가 발생하지 않는가?
- [x] 정해진 디자인 시스템(Color, Font)을 준수하였는가?
- [x] 불필요한 console.log는 제거하였는가?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 프롬프트 복사 기능을 통합해 HTML 콘텐츠도 읽기 쉬운 일반 텍스트로 복사되도록 개선했습니다.
  - 복사 성공·실패 및 빈 콘텐츠 상황에 안내 메시지를 제공합니다.
  - 소셜 로그인 시 세션 갱신 안정성을 개선했습니다.

- **버그 수정**
  - 댓글 입력 길이 제한을 일관되게 적용했습니다.
  - 에디터에서 이미지·동영상이 원치 않게 삽입되는 문제를 방지했습니다.
  - 외부 링크와 새 탭 링크가 올바르게 동작하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->