### PR TITLE
fix(P0-02, P0-05): 토큰 갱신 및 인기순 정렬 버그 수정

### DIFF
--- a/app/(afterLogin)/(dashboard)/(community-category)/_components/community-list-section.tsx
+++ b/app/(afterLogin)/(dashboard)/(community-category)/_components/community-list-section.tsx
@@ -10,7 +10,7 @@ import { useGetPrompts } from "@/hooks/use-prompt-list";
 
 import { CommunityPromptItem } from "../../_types/community-type";
 import { CommunitySection } from "../_components/community";
-import { SortGroup } from "../_components/sort-group";
+import { SortGroup, SortType } from "../_components/sort-group";
 
 /** 슬러그 → categoryId 변환. 매핑 없으면 "all" 반환 */
 export function resolveCategoryParam(slug: string): string {
@@ -26,8 +26,9 @@ export function resolveCategoryParam(slug: string): string {
 export function CommunityListSection() {
   const { getParam } = useQueryParams();
   const categorySlug = getParam("category") || "all";
-  const sort = (getParam("sort") as "latest" | "likes") || "latest";
-  const isPopular = sort === "likes";
+  const rawSort = getParam("sort");
+  const sort: SortType = rawSort === "popular" ? "popular" : "latest";
+  const isPopular = sort === "popular";
 
   // 슬러그 → "1", "2" ... 또는 "all"
   // 인기순(/prompts/likeDesc)은 category 파라미터 없으므로 "all" 고정

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -60,6 +60,7 @@ export const { handlers, auth, signIn, signOut, update } = NextAuth({
             maxAge: 30 * 24 * 60 * 60, // 30일
           });
 
+          // 1) 바디에 refreshToken이 있으면 그대로 저장 (BE가 @JsonIgnore를 제거한 경우)
           if (refreshToken) {
             cookieStore.set("refresh_token", refreshToken, {
               path: "/",
@@ -70,9 +71,36 @@ export const { handlers, auth, signIn, signOut, update } = NextAuth({
             });
           }
 
+          // 2) 바디에 없으면 Set-Cookie 헤더에서 파싱 (server-to-server fetch이므로 수동 처리 필요)
+          //    BE의 @JsonIgnore로 바디에서 제외되어도, Set-Cookie로는 내려오므로 여기서 읽어 저장
+          let resolvedRefreshToken = refreshToken;
+          if (!resolvedRefreshToken) {
+            const setCookieHeader = response.headers.getSetCookie?.();
+            if (setCookieHeader) {
+              for (const cookie of setCookieHeader) {
+                if (cookie.startsWith("refresh_token=")) {
+                  const firstSegment = cookie.split(";")[0];
+                  const eqIdx = firstSegment.indexOf("=");
+                  const refreshTokenValue =
+                    eqIdx >= 0 ? firstSegment.slice(eqIdx + 1) : "";
+                  if (refreshTokenValue) {
+                    resolvedRefreshToken = refreshTokenValue;
+                    cookieStore.set("refresh_token", refreshTokenValue, {
+                      httpOnly: true,
+                      secure: process.env.NODE_ENV === "production",
+                      sameSite: "lax",
+                      path: "/",
+                      maxAge: 30 * 24 * 60 * 60,
+                    });
+                  }
+                }
+              }
+            }
+          }
+
           // 신규 유저든 기존 유저든 일단 정보를 user 객체에 보관
           user.accessToken = accessToken;
-          user.refreshToken = refreshToken;
+          user.refreshToken = resolvedRefreshToken;
           user.isNewUser = isNewUser;
           user.registrationStatus = registrationStatus;
           user.provider = account.provider; // 소셜 제공자 정보 저장


### PR DESCRIPTION
## 🛠️ 변경 사항
> 무엇을 변경했는지 간결하게 설명해주세요.

P0-02: signIn 콜백에서 BE 응답의 Set-Cookie 헤더 파싱하여 refresh_token 저장
- BE가 @JsonIgnore로 바디에서 refreshToken을 제외하므로 Set-Cookie에서 추출
- refreshBackendToken()과 동일한 파싱 로직을 signIn에도 적용
- user.refreshToken에 resolvedRefreshToken 할당

P0-05: 인기순 정렬 문자열 불일치 수정 (likes -> popular)
- sort-group.tsx의 SortType을 import하여 타입 안전성 확보
- 타입 단언(as) 제거, 런타임 검증으로 대체

## 📸 스크린샷 (선택)
> UI 변경이 있는 경우 스크린샷을 첨부해주세요.

## ✅ 체크리스트
- [ ] 빌드 에러가 발생하지 않는가?
- [ ] 정해진 디자인 시스템(Color, Font)을 준수하였는가?
- [ ] 불필요한 console.log는 제거하였는가?

## 🔗 연결된 이슈
- Closes #이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 커뮤니티 목록에서 인기순과 최신순 정렬을 지원합니다.
  * 인기순 정렬 시 전체 카테고리의 인기 게시글을 확인할 수 있습니다.
  * 정렬 옵션이 올바르게 적용되도록 개선되었습니다.

* **버그 수정**
  * 로그인 후 세션 유지에 필요한 인증 정보 저장이 안정적으로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->