### PR TITLE
fix(auth): P1-11 에러 파싱 경로 수정 및 P1-15 세션 응답 내 토큰 중복 노출 제거

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -189,7 +189,6 @@ export const { handlers, auth, signIn, signOut, update } = NextAuth({
       session.error = token.error as string;
 
       if (session.user) {
-        session.user.accessToken = token.accessToken as string;
         session.user.id =
           (token.backendUserId as string) || (token.sub as string);
         session.user.email = token.email as string;

--- a/queries/api/onboarding.ts
+++ b/queries/api/onboarding.ts
@@ -27,7 +27,7 @@ export async function postNickname(nickname: string, token: string) {
     let errorData;
     try {
       const result = await res.json();
-      errorData = result.data;
+      errorData = result.error;
     } catch {
       // JSON 파싱 실패 시 기본 에러
     }
@@ -58,7 +58,7 @@ export async function putBasic(
     let errorData;
     try {
       const result = await res.json();
-      errorData = result.data;
+      errorData = result.error;
     } catch {
       // JSON 파싱 실패 시 기본 에러
     }
@@ -87,7 +87,7 @@ export async function putCareer(params: PutCareerParams, token: string) {
     let errorData;
     try {
       const result = await res.json();
-      errorData = result.data;
+      errorData = result.error;
     } catch {
       // JSON 파싱 실패 시 기본 에러
     }
@@ -115,7 +115,7 @@ export async function postComplete(token: string) {
     let errorData;
     try {
       const result = await res.json();
-      errorData = result.data;
+      errorData = result.error;
     } catch {
       // JSON 파싱 실패 시 기본 에러
     }

--- a/queries/api/terms.ts
+++ b/queries/api/terms.ts
@@ -58,7 +58,7 @@ export async function postTerms(termIds: number[], token: string) {
     let errorData: ApiErrorData | undefined;
 
     try {
-      const result = (await res.json()) as ApiResponse<ApiErrorData>;
+      const result = (await res.json()) as { error: ApiErrorData };
       errorData = result.error;
     } catch (error) {
       console.error("Failed to parse error response:", error);

--- a/queries/api/terms.ts
+++ b/queries/api/terms.ts
@@ -59,7 +59,7 @@ export async function postTerms(termIds: number[], token: string) {
 
     try {
       const result = (await res.json()) as ApiResponse<ApiErrorData>;
-      errorData = result.data;
+      errorData = result.error;
     } catch (error) {
       console.error("Failed to parse error response:", error);
     }


### PR DESCRIPTION
## 🛠️ 변경 사항
> 무엇을 변경했는지 간결하게 설명해주세요.
- **P1-11 해결**: 온보딩 및 약관 동의 API 호출 시 에러 응답 파싱 경로를 수정했습니다. (`result.data` -> `result.error`) 이제 "요청 실패 (400)" 대신 백엔드가 보내는 정확한 에러 메시지(예: 닉네임 중복 등)가 노출됩니다.
- **P1-15 해결**: `/api/auth/session` 응답 시 브라우저에 불필요하게 중복 노출되던 JWT 액세스 토큰 표면적을 줄였습니다. (`session.user.accessToken` 객체 프로퍼티 제거)
## 📸 스크린샷 (선택)
> UI 변경이 있는 경우 스크린샷을 첨부해주세요.
(스크린샷이 있다면 여기에 추가해 주세요)
## ✅ 체크리스트
- [x] 빌드 에러가 발생하지 않는가?
- [x] 정해진 디자인 시스템(Color, Font)을 준수하였는가?
- [x] 불필요한 console.log는 제거하였는가?
## 🔗 연결된 이슈

