### PR TITLE
Fix/token-hardening (P0-02, P1-15 개선)

### DIFF
--- a/app/(afterLogin)/mypage/MypageLeftSection.tsx
+++ b/app/(afterLogin)/mypage/MypageLeftSection.tsx
@@ -5,12 +5,12 @@ import { signOut, useSession } from "next-auth/react";
 import { toast } from "sonner";
 
 import { AuthProvider } from "@/app/(beforeLogin)/(auth)/constant";
+import { clearAuthCookies, logoutOnServer } from "@/app/actions/auth-actions";
 import UserProfile from "@/components/mypage/user-profile";
 import { BaseButton } from "@/components/shared/button";
 import { useUserProfile } from "@/hooks/use-mypage";
 import { ROUTES } from "@/lib/routes";
-import { clearAuthCookiesClientSide } from "@/lib/utils";
-import { deleteUserAccount, postLogout } from "@/queries/api/auth";
+import { deleteUserAccount } from "@/queries/api/auth";
 
 import MypageLeftSkeleton from "./MypageLeftSkeleton";
 
@@ -24,7 +24,7 @@ export default function MypageLeftSection() {
   const handleLogout = async () => {
     if (confirm("로그아웃 하시겠습니까?")) {
       try {
-        await postLogout();
+        await logoutOnServer();
         queryClient.clear();
         toast.success("로그아웃 되었습니다.");
       } catch {
@@ -52,7 +52,7 @@ export default function MypageLeftSection() {
       });
       await signOut({ redirect: false });
 
-      clearAuthCookiesClientSide();
+      await clearAuthCookies();
 
       queryClient.clear();
       alert("회원 탈퇴가 완료되었습니다.");

--- a/app/actions/auth-actions.ts
+++ b/app/actions/auth-actions.ts
@@ -2,9 +2,38 @@
 
 import { cookies } from "next/headers";
 
+const REFRESH_TOKEN_COOKIE = "refresh_token";
+
 export async function clearAuthCookies() {
   const cookieStore = await cookies();
 
   cookieStore.delete("accessToken");
-  cookieStore.delete("refresh_token");
+  cookieStore.delete(REFRESH_TOKEN_COOKIE);
+}
+
+/**
+ * 로그아웃을 서버에서 처리한다.
+ *
+ * refresh_token 은 keep-prog.com 에 httpOnly 로 있어 브라우저가 api.keep-prog.com 으로
+ * 직접 보낼 수 없다. 서버가 Cookie 헤더에 실어야 BE 가 DB 의 토큰을 폐기한다.
+ * 클라이언트에서 그냥 호출하면 BE 는 토큰 없이 받아 아무것도 폐기하지 않는다.
+ */
+export async function logoutOnServer() {
+  const cookieStore = await cookies();
+  const refreshToken = cookieStore.get(REFRESH_TOKEN_COOKIE)?.value;
+
+  if (refreshToken) {
+    try {
+      await fetch(`${process.env.NEXT_PUBLIC_BACKEND_API_URL}/auth/logout`, {
+        method: "POST",
+        headers: { Cookie: `${REFRESH_TOKEN_COOKIE}=${refreshToken}` },
+      });
+    } catch (error) {
+      // 서버 폐기에 실패해도 로컬 세션은 끊는다.
+      console.error("Failed to revoke refresh token:", error);
+    }
+  }
+
+  cookieStore.delete("accessToken");
+  cookieStore.delete(REFRESH_TOKEN_COOKIE);
 }

--- a/app/types/next-auth.d.ts
+++ b/app/types/next-auth.d.ts
@@ -25,9 +25,10 @@ declare module "next-auth" {
     email?: string;
   }
 
+  // 이 인터페이스의 값은 /api/auth/session 으로 브라우저에 그대로 나간다.
+  // refreshToken 을 다시 넣지 말 것 — 14일짜리 토큰이 JS 에 노출된다.
   interface Session {
     accessToken?: string;
-    refreshToken?: string;
     isNewUser?: boolean; // 가입 페이지 리다이렉트 판단용
     registrationStatus?: string;
     provider?: string; // 가입 시 백엔드 전달용
@@ -35,7 +36,6 @@ declare module "next-auth" {
     error?: string;
     user: {
       id?: string;
-      accessToken?: string;
     } & DefaultSession["user"];
   }
 }

--- a/components/auth/auth-watcher.tsx
+++ b/components/auth/auth-watcher.tsx
@@ -9,20 +9,6 @@ export function AuthWatcher() {
   const { data: session, update } = useSession();
   const isSigningOut = useRef(false);
 
-  // accessToken → 쿠키 동기화 (CSR에서 fetcher가 읽을 수 있도록)
-  useEffect(() => {
-    const token = (session as unknown as Record<string, unknown>)
-      ?.accessToken as string | undefined;
-
-    if (token) {
-      setFetcherToken(token);
-      document.cookie = `accessToken=${token}; path=/; max-age=${60 * 60 * 24 * 30}; SameSite=Lax`;
-    } else if (session === null) {
-      setFetcherToken(null);
-      document.cookie = "accessToken=; path=/; max-age=0; SameSite=Lax";
-    }
-  }, [session]);
-
   // 만료된 토큰 감지 → 갱신 시도 → 실패 시 로그아웃
   useEffect(() => {
     if (session?.accessToken) {
@@ -36,7 +22,6 @@ export function AuthWatcher() {
         const newSession = await update();
         if (newSession?.error === "AccessTokenExpired") {
           isSigningOut.current = true;
-          document.cookie = "accessToken=; path=/; max-age=0; SameSite=Lax";
           signOut({ callbackUrl: "/signin" });
         }
       }

--- a/hooks/use-logout.ts
+++ b/hooks/use-logout.ts
@@ -1,12 +1,12 @@
 import { useMutation } from "@tanstack/react-query";
 import { signOut } from "next-auth/react";
 
+import { logoutOnServer } from "@/app/actions/auth-actions";
 import { ROUTES } from "@/lib/routes";
-import { postLogout } from "@/queries/api/auth";
 
 export const useLogout = () => {
   return useMutation({
-    mutationFn: postLogout,
+    mutationFn: logoutOnServer,
     onSettled: () => {
       signOut({
         callbackUrl: ROUTES.auth.SIGNIN,

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -5,6 +5,51 @@ import { JWT } from "next-auth/jwt";
 import KakaoProvider from "next-auth/providers/kakao";
 import NaverProvider from "next-auth/providers/naver";
 
+const REFRESH_TOKEN_COOKIE = "refresh_token";
+
+// BE 의 jwt.refresh-expiration(14일)과 맞춘다.
+const REFRESH_TOKEN_MAX_AGE = 14 * 24 * 60 * 60;
+
+/**
+ * BE 는 refresh_token 을 응답 바디가 아니라 Set-Cookie 로만 내려준다(@JsonIgnore).
+ * 이 요청을 보낸 주체가 브라우저가 아니라 Next 서버라서 쿠키가 자동 저장되지 않으므로 직접 꺼낸다.
+ */
+function readRefreshTokenFromResponse(response: Response): string | null {
+  const setCookies = response.headers.getSetCookie?.() ?? [];
+
+  for (const cookie of setCookies) {
+    if (!cookie.startsWith(`${REFRESH_TOKEN_COOKIE}=`)) continue;
+
+    const firstSegment = cookie.split(";")[0];
+    const eqIdx = firstSegment.indexOf("=");
+    const value = eqIdx >= 0 ? firstSegment.slice(eqIdx + 1) : "";
+
+    if (value) return value;
+  }
+
+  return null;
+}
+
+/**
+ * 콜백은 쿠키를 쓸 수 없는 컨텍스트(서버 컴포넌트·미들웨어)에서도 돈다.
+ * 그곳에서는 조용히 실패하고 false 를 준다. 호출부가 이어갈지 미룰지 판단한다.
+ */
+async function persistRefreshToken(value: string): Promise<boolean> {
+  try {
+    const cookieStore = await cookies();
+    cookieStore.set(REFRESH_TOKEN_COOKIE, value, {
+      path: "/",
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: REFRESH_TOKEN_MAX_AGE,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export const { handlers, auth, signIn, signOut, update } = NextAuth({
   providers: [
     KakaoProvider({
@@ -48,59 +93,28 @@ export const { handlers, auth, signIn, signOut, update } = NextAuth({
 
         const resData = await response.json();
         if (resData.success) {
-          const { isNewUser, accessToken, refreshToken, registrationStatus } =
-            resData.data;
+          const { isNewUser, accessToken, registrationStatus } = resData.data;
 
-          const cookieStore = await cookies();
-          cookieStore.set("accessToken", accessToken, {
-            path: "/",
-            httpOnly: true,
-            secure: process.env.NODE_ENV === "production",
-            sameSite: "lax",
-            maxAge: 30 * 24 * 60 * 60, // 30일
-          });
+          // 1) BE 가 @JsonIgnore 를 떼면 바디로 내려온다.
+          // 2) 지금은 Set-Cookie 로만 오고, 이 요청은 Next 서버가 보낸 것이라 자동 저장되지 않는다.
+          const refreshToken =
+            (resData.data.refreshToken as string | undefined) ??
+            readRefreshTokenFromResponse(response);
 
-          // 1) 바디에 refreshToken이 있으면 그대로 저장 (BE가 @JsonIgnore를 제거한 경우)
           if (refreshToken) {
-            cookieStore.set("refresh_token", refreshToken, {
-              path: "/",
-              httpOnly: true,
-              secure: process.env.NODE_ENV === "production",
-              sameSite: "lax",
-              maxAge: 30 * 24 * 60 * 60,
-            });
+            await persistRefreshToken(refreshToken);
           }
 
-          // 2) 바디에 없으면 Set-Cookie 헤더에서 파싱 (server-to-server fetch이므로 수동 처리 필요)
-          //    BE의 @JsonIgnore로 바디에서 제외되어도, Set-Cookie로는 내려오므로 여기서 읽어 저장
-          let resolvedRefreshToken = refreshToken;
-          if (!resolvedRefreshToken) {
-            const setCookieHeader = response.headers.getSetCookie?.();
-            if (setCookieHeader) {
-              for (const cookie of setCookieHeader) {
-                if (cookie.startsWith("refresh_token=")) {
-                  const firstSegment = cookie.split(";")[0];
-                  const eqIdx = firstSegment.indexOf("=");
-                  const refreshTokenValue =
-                    eqIdx >= 0 ? firstSegment.slice(eqIdx + 1) : "";
-                  if (refreshTokenValue) {
-                    resolvedRefreshToken = refreshTokenValue;
-                    cookieStore.set("refresh_token", refreshTokenValue, {
-                      httpOnly: true,
-                      secure: process.env.NODE_ENV === "production",
-                      sameSite: "lax",
-                      path: "/",
-                      maxAge: 30 * 24 * 60 * 60,
-                    });
-                  }
-                }
-              }
-            }
+          // 이전 버전이 심어둔 accessToken 쿠키를 정리한다. 읽는 곳이 없고 수명만 30일이었다.
+          try {
+            (await cookies()).delete("accessToken");
+          } catch {
+            // 쿠키 쓰기가 막힌 컨텍스트
           }
 
           // 신규 유저든 기존 유저든 일단 정보를 user 객체에 보관
           user.accessToken = accessToken;
-          user.refreshToken = resolvedRefreshToken;
+          user.refreshToken = refreshToken ?? undefined;
           user.isNewUser = isNewUser;
           user.registrationStatus = registrationStatus;
           user.provider = account.provider; // 소셜 제공자 정보 저장
@@ -179,9 +193,10 @@ export const { handlers, auth, signIn, signOut, update } = NextAuth({
       }
       return token;
     },
+    // 여기에 담은 값은 /api/auth/session 응답으로 브라우저 JS 에 그대로 노출된다.
+    // 리프레시 토큰은 절대 올리지 않는다. 액세스 토큰도 최상위 하나로만 둔다.
     async session({ session, token }) {
       session.accessToken = token.accessToken as string;
-      session.refreshToken = token.refreshToken as string;
       session.registrationStatus = token.registrationStatus as string;
       session.isNewUser = token.isNewUser as boolean;
       session.provider = token.provider as string;
@@ -202,23 +217,58 @@ export const { handlers, auth, signIn, signOut, update } = NextAuth({
   },
 });
 
+// BE 는 이미 쓴 리프레시 토큰이 다시 오면 탈취로 판단해 그 사용자의 전 기기 토큰을 폐기한다.
+// 만료 직후 여러 요청이 각자 갱신에 나서면 정상 사용자가 통째로 로그아웃되므로,
+// 같은 토큰에 대한 갱신은 하나로 묶는다.
+const inFlightRefreshes = new Map<string, Promise<JWT>>();
+
 async function refreshBackendToken(token: JWT): Promise<JWT> {
+  let refreshToken = token.refreshToken;
+
   try {
-    const cookieStore = await cookies();
-    let cookieString = cookieStore.toString();
+    refreshToken =
+      (await cookies()).get(REFRESH_TOKEN_COOKIE)?.value ?? refreshToken;
+  } catch {
+    // 쿠키를 읽을 수 없는 컨텍스트. NextAuth JWT 에 남은 값으로 진행한다.
+  }
 
-    // 브라우저 쿠키에 refresh_token이 없더라도 NextAuth 토큰에서 가져와 헤더에 추가
-    if (token.refreshToken && !cookieString.includes("refresh_token=")) {
-      cookieString += `${cookieString ? "; " : ""}refresh_token=${token.refreshToken}`;
-    }
+  if (!refreshToken) {
+    console.error("Token refresh error: no refresh token available");
+    return { ...token, error: "AccessTokenExpired" };
+  }
 
+  // BE 는 갱신할 때마다 리프레시 토큰을 교체하고 옛 토큰을 폐기한다.
+  // 교체분을 저장할 수 없는 곳에서 갱신하면 그 값을 잃고, 다음 갱신이 폐기된 토큰으로 나가
+  // 전 기기 로그아웃을 부른다. 지금 값을 그대로 다시 심어 쓰기 가능 여부를 확인하고,
+  // 불가능하면 미룬다. 쿠키를 쓸 수 있는 /api/auth/session 요청에서 갱신된다.
+  if (!(await persistRefreshToken(refreshToken))) {
+    return token;
+  }
+
+  const running = inFlightRefreshes.get(refreshToken);
+  if (running) return running;
+
+  const key = refreshToken;
+  const request = requestNewTokens(token, key).finally(() => {
+    inFlightRefreshes.delete(key);
+  });
+  inFlightRefreshes.set(key, request);
+
+  return request;
+}
+
+async function requestNewTokens(
+  token: JWT,
+  refreshToken: string
+): Promise<JWT> {
+  try {
     const response = await fetch(
       `${process.env.NEXT_PUBLIC_BACKEND_API_URL}/auth/refresh`,
       {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Cookie: cookieString,
+          Cookie: `${REFRESH_TOKEN_COOKIE}=${refreshToken}`,
         },
       }
     );
@@ -228,7 +278,6 @@ async function refreshBackendToken(token: JWT): Promise<JWT> {
     }
 
     const resData = await response.json();
-    // 2. 새 토큰 파싱
     const newAccessToken =
       typeof resData?.data === "string"
         ? resData.data
@@ -242,43 +291,17 @@ async function refreshBackendToken(token: JWT): Promise<JWT> {
 
     const decoded = jwtDecode<{ exp: number }>(newAccessToken);
 
-    // 새 accessToken을 쿠키에 저장
-    cookieStore.set("accessToken", newAccessToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      path: "/",
-      maxAge: 30 * 24 * 60 * 60, // 30일
-    });
-
-    // 백엔드가 Set-Cookie로 보낸 refresh_token을 Next.js 서버에서 수동 전달
-    let newRefreshToken = token.refreshToken;
-    const setCookieHeader = response.headers.getSetCookie?.();
-    if (setCookieHeader) {
-      for (const cookie of setCookieHeader) {
-        if (cookie.startsWith("refresh_token=")) {
-          const firstSegment = cookie.split(";")[0];
-          const eqIdx = firstSegment.indexOf("=");
-          const refreshTokenValue =
-            eqIdx >= 0 ? firstSegment.slice(eqIdx + 1) : "";
-          if (refreshTokenValue) {
-            newRefreshToken = refreshTokenValue;
-            cookieStore.set("refresh_token", refreshTokenValue, {
-              httpOnly: true,
-              secure: process.env.NODE_ENV === "production",
-              sameSite: "lax",
-              path: "/",
-              maxAge: 30 * 24 * 60 * 60, // 30일
-            });
-          }
-        }
-      }
+    // BE 는 갱신할 때마다 리프레시 토큰도 새로 발급하고 옛 토큰을 폐기한다(로테이션).
+    // 새 값을 놓치면 다음 갱신이 폐기된 토큰으로 나가 전 기기 로그아웃을 부른다.
+    const rotated = readRefreshTokenFromResponse(response);
+    if (rotated) {
+      await persistRefreshToken(rotated);
     }
 
     return {
       ...token,
       accessToken: newAccessToken,
-      refreshToken: newRefreshToken,
+      refreshToken: rotated ?? refreshToken,
       accessTokenExpires: decoded.exp * 1000,
       error: undefined,
     };

--- a/lib/fetcher.ts
+++ b/lib/fetcher.ts
@@ -1,5 +1,6 @@
 import ky from "ky";
 import { NextRequest } from "next/server";
+import type { Session } from "next-auth";
 
 export interface ApiResponse<T> {
   code: string;
@@ -42,6 +43,22 @@ let clientInMemoryToken: string | null = null;
 
 export const setFetcherToken = (token: string | null) => {
   clientInMemoryToken = token;
+};
+
+// 토큰이 만료되면 화면에 걸린 요청들이 한꺼번에 401 을 받는다. 각자 세션을 갱신하면
+// BE 가 두 번째부터를 리프레시 토큰 재사용으로 보고 전 기기 토큰을 폐기하므로,
+// 동시에 들어온 갱신은 한 번으로 묶는다.
+let sessionRefresh: Promise<Session | null> | null = null;
+
+const refreshSessionOnce = () => {
+  if (!sessionRefresh) {
+    sessionRefresh = import("next-auth/react")
+      .then(({ getSession }) => getSession())
+      .finally(() => {
+        sessionRefresh = null;
+      });
+  }
+  return sessionRefresh;
 };
 
 export const fetcher = ky.create({
@@ -126,17 +143,10 @@ export const fetcher = ky.create({
             ) {
               if (typeof window !== "undefined") {
                 try {
-                  const { getSession, signOut } =
-                    await import("next-auth/react");
-
-                  const event = new MessageEvent("message", {
-                    data: { trigger: "getSession", event: "session" },
-                  });
-                  window.dispatchEvent(event);
-
-                  const newSession = await getSession();
+                  const newSession = await refreshSessionOnce();
 
                   if (newSession?.error === "AccessTokenExpired") {
+                    const { signOut } = await import("next-auth/react");
                     await signOut({ callbackUrl: "/signin" });
                   } else if (newSession?.accessToken) {
                     setFetcherToken(newSession.accessToken);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -84,19 +84,3 @@ export function htmlToPlainText(html: string) {
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 }
-
-export const clearAuthCookiesClientSide = () => {
-  const cookiesToClear = [
-    "next-auth.session-token",
-    "next-auth.csrf-token",
-    "next-auth.callback-url",
-    "__Secure-next-auth.session-token",
-    "__Host-next-auth.csrf-token",
-    "__Secure-next-auth.callback-url",
-  ];
-
-  cookiesToClear.forEach((cookieName) => {
-    document.cookie = `${cookieName}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
-    document.cookie = `${cookieName}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=${window.location.hostname};`;
-  });
-};

--- a/queries/api/auth.ts
+++ b/queries/api/auth.ts
@@ -1,4 +1,4 @@
-import { ApiResponse, fetcher } from "@/lib/fetcher";
+import { fetcher } from "@/lib/fetcher";
 
 export const postAuth = async ({
   provider,
@@ -28,9 +28,8 @@ export const postAuth = async ({
   return response.json();
 };
 
-export const postLogout = async () => {
-  return await fetcher.post("auth/logout").json<ApiResponse<object>>();
-};
+// 로그아웃은 refresh_token 쿠키를 실어야 해서 서버에서 처리한다.
+// app/actions/auth-actions.ts 의 logoutOnServer 를 쓸 것.
 
 export interface WithdrawRequest {
   reason?: string;


### PR DESCRIPTION
## 🛠️ 변경 사항
- session에서 Refresh Token이 노출되어, 이 부분 제거
  - 기존에는 Refresh Token 자체를 꺼내지 않고 있었음 (항상 undefined가 들어감)
  - 이전 커밋들에서, 이제 Cookie에서 Refresh token을 가져오기 시작
  - 그러나 session 쪽에서 Refresh Token도 꺼내서 사용하고 있었음, 매핑하는 부분 제거
 

## ✅ 체크리스트
- [ ] 빌드 에러가 발생하지 않는가?
- [ ] 정해진 디자인 시스템(Color, Font)을 준수하였는가?
- [ ] 불필요한 console.log는 제거하였는가?

## 🔗 연결된 이슈
- Closes #이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **보안 개선**
  * 인증 토큰이 브라우저 세션에 직접 노출되지 않도록 보호를 강화했습니다.
  * 로그아웃 및 회원 탈퇴 시 서버에서 인증 쿠키를 안전하게 정리합니다.

* **버그 수정**
  * 토큰 만료 시 중복 갱신 요청을 방지하고, 갱신 후 요청이 정상적으로 재시도되도록 개선했습니다.
  * 로그아웃 요청이 실패하더라도 로컬 인증 정보가 정리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->