### PR TITLE
Qa/좋아요 수 렌더 및 마이페이지에서 원문 이동

### DIFF
--- a/components/mypage/articleCard.tsx
+++ b/components/mypage/articleCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { formatRelative } from "@/lib/datetime";
-import { stripHtml } from "@/lib/utils";
+import { cn, stripHtml } from "@/lib/utils";
 
 import { BaseButton } from "../shared/button";
 
@@ -35,10 +35,11 @@ export function LikedArticleCard({
 }: LikedArticleCardProps) {
   return (
     <article
-      className={STYLES.CARD_CONTAINER}
+      className={cn(STYLES.CARD_CONTAINER, onClick && "cursor-pointer")}
       {...(onClick && {
         role: "button",
         tabIndex: 0,
+        onClick,
         onKeyDown: (e: React.KeyboardEvent) => {
           if (e.key === "Enter" || e.key === " ") onClick();
         },

--- a/hooks/use-prompt-list.ts
+++ b/hooks/use-prompt-list.ts
@@ -179,7 +179,8 @@ export const useToggleLikeMutation = () => {
                       ? {
                           ...item,
                           isLiked: !isLiked,
-                          likes: isLiked
+                          // 카드가 렌더링하는 필드는 likeCount 이다. (PromptBase 에 likes 필드는 없음)
+                          likeCount: isLiked
                             ? Math.max((item.likeCount ?? 0) - 1, 0)
                             : (item.likeCount ?? 0) + 1,
                         }


### PR DESCRIPTION
## 🛠️ 변경 사항

- 좋아요 개수가 UI에 바로 반영되지 않았던 문제 수정
- 마이페이지 > 내 활동 > 좋아요 한 프롬프트에서 카드 클릭시에도 원 게시글로 이동하지 않았던 문제 해결 (Enter/Space 인식만 하고있었음)

## ✅ 체크리스트
- [ ] 빌드 에러가 발생하지 않는가?
- [ ] 정해진 디자인 시스템(Color, Font)을 준수하였는가?
- [ ] 불필요한 console.log는 제거하였는가?

## 🔗 연결된 이슈
- Closes #이슈번호
