### PR TITLE
fix - 마이페이지에서 "내 활동 목록"의 페이지네이션이 렌더링되도록 (P0-08)

### DIFF
--- a/app/(afterLogin)/mypage/MypageActivity.tsx
+++ b/app/(afterLogin)/mypage/MypageActivity.tsx
@@ -13,6 +13,9 @@ import { useSubTabFilters } from "@/hooks/use-filters";
 import { useLikedPrompts, useUserPrompts } from "@/hooks/use-mypage";
 import { cn } from "@/lib/utils";
 
+// 한 페이지 노출 건수. useLikedPrompts/useUserPrompts 의 size 와 totalPages 계산이 이 값을 공유한다.
+const PAGE_SIZE = 4;
+
 export default function MypageActivitySection() {
   const router = useRouter();
   const { copyById } = useCopyPrompt();
@@ -28,11 +31,13 @@ export default function MypageActivitySection() {
   const { data: likedData, isLoading: isLikedLoading } = useLikedPrompts({
     userId: userId as string,
     page: currentPage,
+    size: PAGE_SIZE,
     enabled: !!userId && activeSub === "liked",
   });
   const { data: postedData, isLoading: isPostedLoading } = useUserPrompts({
     userId: userId as string,
     page: currentPage,
+    size: PAGE_SIZE,
     enabled: !!userId && activeSub === "posted",
   });
 
@@ -51,7 +56,10 @@ export default function MypageActivitySection() {
 
   const hasContent =
     currentData && currentData.prompts && currentData.prompts.length > 0;
-  const totalPages = currentData?.pageInfo?.totalPages ?? 0;
+  // BE 가 pageInfo 를 주면 그대로, 아니면(현재 실서버 응답은 totalCount 만) 계산한다. (P0-08)
+  const totalPages =
+    currentData?.pageInfo?.totalPages ??
+    Math.ceil((currentData?.totalCount ?? 0) / PAGE_SIZE);
 
   return (
     <div className="flex flex-col gap-6 w-full">

--- a/mocks/handlers/mypage-handlers.ts
+++ b/mocks/handlers/mypage-handlers.ts
@@ -40,7 +40,6 @@ export const mypageHandlers = [
   http.get(`${BASE_URL}/users/:userId/prompts`, ({ request, params }) => {
     const url = new URL(request.url);
     const page = Number(url.searchParams.get("page") || "0");
-    const size = Number(url.searchParams.get("size") || "4");
     const { userId } = params;
 
     return HttpResponse.json<UserPromptsResponse>({
@@ -58,20 +57,14 @@ export const mypageHandlers = [
             isLiked: true,
           },
         ],
-        pageInfo: {
-          currentPage: page,
-          pageSize: size,
-          totalElements: 45,
-          totalPages: Math.ceil(45 / size),
-          isLast: page >= 11,
-        },
+        // 실서버 응답 형태에 맞춰 totalCount 만 내려준다 (BE 는 pageInfo 미제공). (P0-08)
+        totalCount: 45,
       },
     });
   }),
   http.get(`${BASE_URL}/users/:userId/liked`, ({ request, params }) => {
     const url = new URL(request.url);
     const page = Number(url.searchParams.get("page") || "0");
-    const size = Number(url.searchParams.get("size") || "4");
     const { userId } = params;
 
     return HttpResponse.json<UserPromptsResponse>({
@@ -89,13 +82,8 @@ export const mypageHandlers = [
             isLiked: true,
           },
         ],
-        pageInfo: {
-          currentPage: page,
-          pageSize: size,
-          totalElements: 45,
-          totalPages: Math.ceil(45 / size),
-          isLast: page >= 11,
-        },
+        // 실서버 응답 형태에 맞춰 totalCount 만 내려준다 (BE 는 pageInfo 미제공). (P0-08)
+        totalCount: 45,
       },
     });
   }),

--- a/queries/api/types.ts
+++ b/queries/api/types.ts
@@ -58,7 +58,10 @@ export interface PageInfo {
 
 export interface UserPromptsData {
   prompts: PromptItem[];
-  pageInfo: PageInfo;
+  // 실서버가 내려주는 전체 건수. pageInfo 미제공 시 이 값으로 totalPages 를 계산한다. (P0-08)
+  totalCount?: number;
+  // BE 페이징 규약 통일 시 제공 예정(현재 실서버는 미제공, mock 은 제공). 있으면 우선 사용.
+  pageInfo?: PageInfo;
 }
 
 export type UserPromptsResponse = ApiResponse<UserPromptsData>;


### PR DESCRIPTION
## 🛠️ 변경 사항

서버측의 변경 최소화, 클라이언트 측에서 페이지네이션 구현하도록 작업

- totalPages 를 pageInfo 우선, 없으면 Math.ceil(totalCount/size) 로 계산
- UserPromptsData 타입을 실제 응답에 맞춰 totalCount 추가, pageInfo 는 optional
- PAGE_SIZE 상수로 size 요청과 페이지수 계산을 단일화 (size=4 유지)
- MSW 목을 실서버 형태(totalCount)로 정렬해 로컬-실서버 불일치 제거

## ✅ 체크리스트
- [ ] 빌드 에러가 발생하지 않는가?
- [ ] 정해진 디자인 시스템(Color, Font)을 준수하였는가?
- [ ] 불필요한 console.log는 제거하였는가?

## 🔗 연결된 이슈
- Closes #이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 마이페이지의 좋아요 및 게시 프롬프트 목록에서 페이지당 표시되는 항목 수를 일관되게 적용했습니다.
  * 페이지 정보가 제공되지 않는 경우에도 전체 개수로 페이지 수를 계산해 목록 탐색이 원활하게 동작합니다.
  * 프롬프트 목록 응답의 전체 항목 수를 지원하도록 데이터 처리를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->