### PR TITLE
fix: 커뮤니티 목록 제목 옆 [n] 을 좋아요 수에서 댓글 수로 교체

### DIFF
--- a/app/(afterLogin)/(dashboard)/(community-category)/_components/community-list-section.tsx
+++ b/app/(afterLogin)/(dashboard)/(community-category)/_components/community-list-section.tsx
@@ -55,6 +55,7 @@ export function CommunityListSection() {
           jobCategory: (item.category?.name ||
             "ETC") as CommunityPromptItem["jobCategory"],
           likeCount: item.likeCount || 0,
+          commentCount: item.commentCount || 0,
           copyCount: Number(item.copyCount || 0),
           authorNickname: item.userName || item.nickname || "익명",
           createdAt: item.createdAt ?? null,

--- a/app/(afterLogin)/(dashboard)/(community-category)/_components/community.tsx
+++ b/app/(afterLogin)/(dashboard)/(community-category)/_components/community.tsx
@@ -51,8 +51,10 @@ export function CommunityItem(props: CommunityPromptItem) {
       href={ROUTES.prompt.DETAIL(props.id.toString())}
       className="py-4 px-3 flex items-center justify-between text-black gap-x-5 hover:bg-gray-50 transition-colors"
     >
+      {/* 제목 옆 [n]은 댓글 수. 오른쪽 아이콘이 이미 좋아요 수를 보여주므로 겹치지 않는다. */}
       <h3 className="label-large font-bold">
-        {props.title} [{props.likeCount}]
+        {props.title}
+        {props.commentCount > 0 && ` [${props.commentCount}]`}
       </h3>
 
       <div className="flex items-center label-small gap-x-4 text-gray-600">

--- a/app/(afterLogin)/(dashboard)/(community-category)/search/_components/search-section.tsx
+++ b/app/(afterLogin)/(dashboard)/(community-category)/search/_components/search-section.tsx
@@ -40,6 +40,7 @@ export function SearchSection({ q: initialQ }: { q?: string }) {
           jobCategory: (item.category?.name ||
             "ETC") as CommunityPromptItem["jobCategory"],
           likeCount: item.likeCount || 0,
+          commentCount: item.commentCount || 0,
           copyCount: Number(item.copyCount || 0),
           authorNickname: item.nickname || item.userName || "익명",
           createdAt: item.createdAt ?? null,

--- a/app/(afterLogin)/(dashboard)/_types/community-type.ts
+++ b/app/(afterLogin)/(dashboard)/_types/community-type.ts
@@ -8,6 +8,7 @@ interface PromptType {
   preview: string;
   jobCategory: "BACKEND" | "FRONTEND" | "AI" | "ETC";
   likeCount: number;
+  commentCount: number;
   copyCount: number;
   authorNickname: string;
   createdAt: string | null;
@@ -22,6 +23,7 @@ export type CommunityPromptItem = Pick<
   | "preview"
   | "jobCategory"
   | "likeCount"
+  | "commentCount"
   | "copyCount"
   | "authorNickname"
   | "createdAt"

--- a/app/types/type.ts
+++ b/app/types/type.ts
@@ -25,6 +25,7 @@ export interface PromptBase {
   copyCount?: number;
   isLiked?: boolean;
   likeCount?: number;
+  commentCount?: number;
   createdAt: string;
   updatedAt?: string | null;
 }


### PR DESCRIPTION
- 제목 옆 [n] 과 아이템 오른쪽 "좋아요" 아이콘이 같은 likeCount 를 사용하고 있었음
- BE 쪽에서 likeCount, commentCount 별도로 내려주는 방향으로 수정, 이에 맞춰 코드 변경
- 댓글이 없으면 [0] 대신 아무것도 표시하지 않음



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 커뮤니티 게시글과 검색 결과에 댓글 수 정보가 표시됩니다.
  * 댓글이 있는 게시글 제목에는 댓글 수가 대괄호로 표시되며, 댓글이 없으면 표시되지 않습니다.
  * 좋아요 수는 기존과 같이 오른쪽 아이콘 영역에서 확인할 수 있습니다.
  * 댓글 수가 없는 게시글은 기본값 0으로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->